### PR TITLE
Fix Exception

### DIFF
--- a/lib/docsize_cache.js
+++ b/lib/docsize_cache.js
@@ -16,7 +16,7 @@ DocSzCache.prototype.setPcpu = function (pcpu) {
 DocSzCache.prototype.getSize = function (coll, query, opts, data) {
   // If the dataset is null or empty we can't calculate the size
   // Do not process this data and return 0 as the document size.
-  if (!(data && (data.length || (data.size && data.size())))) {
+  if (!(data && (data.length || data.size))) {
     return 0;
   }
 


### PR DESCRIPTION
## Description

The `data` parameter can be either an `Array` or a `Map`, and a Map's `size` property is a `number` and not a `function`, perhaps that changed in JS spec in the past I guess...